### PR TITLE
Modify shutdown order

### DIFF
--- a/src/core/Driver.ts
+++ b/src/core/Driver.ts
@@ -276,32 +276,17 @@ export default class Driver {
      * @param browser
      */
     static async shutdown(browser: Browser) {
-        try {
-            const pages = await browser.pages()
-            for (const page of pages) {
-                await page.close()
-            }
-        } catch (ignored) {
-        }
-
-        const browserProcess = browser.process()
-        if (browserProcess) {
-            const pid = browserProcess.pid
-
-            if (pid) {
-                const pids = await this.getPids(pid)
-                pids.forEach(pid => {
-                    try {
-                        process.kill(pid, 'SIGKILL')
-                    } catch (ignored) {
-                    }
-                })
-            }
-        }
+        const pid = browser.process()?.pid;
+        const pids = pid ? await helper.getPids(pid) : [];
 
         try {
-            await browser.close()
-        } catch (ignored) {
-        }
+            await browser.close();
+        } catch (ignored) {}
+
+        pids.forEach((pid) => {
+            try {
+                process.kill(pid, 'SIGKILL');
+            } catch (ignored) {}
+        });
     }
 }


### PR DESCRIPTION
puppeteer v14.1.1 on macOS 12.4 M1 Pro

Saw the error below when calling `fakeBrowser.shutdown()`, caused by the puppeteer’s `BrowserRunner` code trying to kill the process group when FakeBrowser had already killed all its PIDs.

This commit changes the order to call `browser.close()` _before_ killing the process tree. You may also choose to simply remove the process killing code since [puppeteer already does that](https://github.com/puppeteer/puppeteer/blob/256223a7b18672ae3890bde312986482ea0fed52/src/node/BrowserRunner.ts#L182-L220).

```
Unhandled Rejection at: Promise {
  <rejected> Error: Puppeteer was unable to kill the process which ran the browser binary.
  This means that, on future Puppeteer launches, Puppeteer might not be able to launch the browser.
  Please check your open processes and ensure that the browser processes that Puppeteer launched have been killed.
  If you think this is a bug, please report it on the Puppeteer issue tracker.
  Error cause: Error: kill EPERM
      at process.kill (node:internal/process/per_thread:220:13)
      at BrowserRunner.kill (<removed>/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:196:29)
      at <removed>/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:168:22
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
      at BrowserRunner.kill (<removed>/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:200:23)
      at <removed>/node_modules/puppeteer/lib/cjs/puppeteer/node/BrowserRunner.js:168:22
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
}
```